### PR TITLE
Add serialization and deserializion. This includes serde, schemars and zerocopy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,12 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+schemars = { version = "0.8.8", optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
+zerocopy = { version = "0.6.1", optional = true }
+
+[features]
+default = []
+schemars = ["dep:schemars"]
+serde = ["dep:serde"]
+zerocopy = ["dep:zerocopy"]


### PR DESCRIPTION
This adds serialization and deserialization of FourCC. That includes serde, schemars and zerocopy.

It makes it possible for FourCC to be used as member type in structs that derive one-or-more-of `serde::Serialize`, `serde::Deserialize`, `schemars::JsonSchema`, `zerocopy::AsBytes`, `zerocopy::FromBytes`.