### PR TITLE
feat: `impl const From<FourCC> for u32` if `nightly` feature enabled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ license = "MIT/Apache-2.0"
 schemars = { version = "0.8.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 zerocopy = { version = "0.6.1", optional = true }
+
+[features]
+nightly = []


### PR DESCRIPTION
Hello, I was writing my own FourCC crate, but then I found out that this one existed, but sadly I can't use it for the use case that I currently have.

## Use case

I'm currently using four-cc to map to variants of an enum, like this:

```rust
const fn fourcc(&'static str) -> u32 { ... }

#[repr(u32)]
enum Enum {
    var1 = fourcc("var1"),
    var2 = fourcc("var2"),
}
```

The `rhs` of an enum should always be a `const evaluated expr`, so that is why the function needs to be `const`.

## Problem

The `FourCC` struct can be in a const evaluation expr, but currently something like `u32::from(FourCC(*b"var1"))` would not work, because `u32::from()` is not a `const` function.

So the following is impossible:

```rust
use four_cc::FourCC;

#[repr(u32)]
enum Enum {
    var1 = FourCC(*b"var1").into(),
    var2 = FourCC(*b"var2").into(),
}
```

## Solution

Instead of `impl From<FourCC> for u32`, if the user compiles with the new `nightly` feature, that impl will be `impl const From<FourCC> for u32`, allowing for a `const` and `non-const` context to be able to call the `from()` function.

So something like this:

```rust
#![cfg_attr(feature = "nightly", feature(const_trait_impl))]

// The macro is needed, because the `impl const` syntax doesn't exists on `stable`.
#[cfg(not(feature = "nightly"))]
macro_rules! from_fourcc_for_u32 {
    () => {
        impl From<FourCC> for u32 {
            fn from(val: FourCC) -> Self { ... }
        }
    };
}
#[cfg(feature = "nightly")]
macro_rules! from_fourcc_for_u32 {
    () => {
        impl const From<FourCC> for u32 {
            fn from(val: FourCC) -> Self { ... }
        }
    };
}
from_fourcc_for_u32!();
```

And with that, the example above with the enum will compile ( with the feature enabled obviously ).

## Considerations

With this changes, `stable`  will continue working the same ( msrv is still 1.38, I checked it with `cargo msrv` ), but if someone wishes to use nightly, they have the option.

I don't mind using nightly, but I know some crate maintainers don't like to use nightly features; since this change is so small I don't find it problematic, but you might disagree.

Ultimately, a method called `into_u32()` would also work, but that would be to odd?