### PR TITLE
Implement PartialOrd and Ord traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::fmt::Write;
 use core::result::Result;
+use core::str::FromStr;
 
 /// A _four-character-code_ value.
 ///
@@ -150,6 +151,17 @@ impl PartialOrd for FourCC {
 impl Ord for FourCC {
     fn cmp(&self, other: &Self) -> Ordering {
         self.to_string().cmp(&other.to_string())
+    }
+}
+impl FromStr for FourCC {
+    type Err = u32;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 4 {
+            return Err(s.len() as u32);
+        }
+        let mut buf = [0u8; 4];
+        buf.copy_from_slice(s.as_bytes());
+        Ok(FourCC(buf))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 #![cfg_attr(feature = "nightly", feature(const_trait_impl))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::cmp::Ordering;
 use core::fmt;
 use core::fmt::Write;
 use core::result::Result;
@@ -139,6 +140,19 @@ impl From<u32> for FourCC {
         ])
     }
 }
+impl PartialOrd for FourCC {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // Implement comparison logic here, possibly using the inner FourCC value
+        // For example, if FourCC can be converted to something comparable:
+        self.to_string().partial_cmp(&other.to_string())
+    }
+}
+impl Ord for FourCC {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.to_string().cmp(&other.to_string())
+    }
+}
+
 // The macro is needed, because the `impl const` syntax doesn't exists on `stable`.
 #[cfg(not(feature = "nightly"))]
 macro_rules! from_fourcc_for_u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,14 +247,6 @@ impl<T> FromStrVisitor<T> {
 }
 
 #[cfg(feature = "serde")]
-impl core::str::FromStr for FourCC {
-    type Err = u32;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(s.as_bytes().into())
-    }
-}
-
-#[cfg(feature = "serde")]
 impl<'de, T> serde::de::Visitor<'de> for FromStrVisitor<T>
 where
     T: core::str::FromStr,


### PR DESCRIPTION
I am attempting to use the FourCC values in a match statement, the compiler said that PartialOrd and Ord traits are both necessary.

Also implemented FromStr here.

Implementing something basic but useful here. What do you think?